### PR TITLE
Feature/nathan/cards

### DIFF
--- a/lib/monopoly/application.ex
+++ b/lib/monopoly/application.ex
@@ -16,6 +16,7 @@ defmodule Monopoly.Application do
       # Start a worker by calling: Monopoly.Worker.start_link(arg)
       # {Monopoly.Worker, arg},
       # Start to serve requests, typically the last entry
+      {GameObjects.Game, []},
       MonopolyWeb.Endpoint
     ]
 

--- a/lib/monopoly/backend/card.ex
+++ b/lib/monopoly/backend/card.ex
@@ -14,10 +14,7 @@ defmodule GameObjects.Card do
   end
 
   def apply_effect(%__MODULE__{effect: {:get_out_of_jail, true}, owned: true} = card, player) do
-    %{player |
-    in_jail: false,
-      card: Enum.reject(player.card, fn c -> c.id == card.id end)  # Remove from player's cards
-    }
+    %{player | in_jail: false, cards: Enum.reject(player.cards, fn c -> c.id == card.id end)}
   end
 
   def apply_effect(%__MODULE__{effect: {:get_out_of_jail, true}}, player) do

--- a/lib/monopoly/backend/card.ex
+++ b/lib/monopoly/backend/card.ex
@@ -15,13 +15,13 @@ defmodule GameObjects.Card do
 
   def apply_effect(%__MODULE__{effect: {:get_out_of_jail, true}, owned: true} = card, player) do
     %{player |
-      get_out_of_jail: true,
+    in_jail: false,
       card: Enum.reject(player.card, fn c -> c.id == card.id end)  # Remove from player's cards
     }
   end
 
   def apply_effect(%__MODULE__{effect: {:get_out_of_jail, true}}, player) do
-    %{player | get_out_of_jail: true}
+    %{player | in_jail: false}
   end
 
   def apply_effect(_, player), do: player

--- a/lib/monopoly/backend/card.ex
+++ b/lib/monopoly/backend/card.ex
@@ -1,0 +1,31 @@
+defmodule GameObjects.Card do
+  @moduledoc """
+  This module represents a card and their attributes.
+  """
+
+  defstruct [:id, :name, :type, :effect, :owned]
+
+  def apply_effect(%__MODULE__{effect: {:pay, amount}}, player) do
+    %{player | money: player.money - amount}
+  end
+
+  def apply_effect(%__MODULE__{effect: {:earn, amount}}, player) do
+    %{player | money: player.money + amount}
+  end
+
+  def apply_effect(%__MODULE__{effect: {:get_out_of_jail, true}, owned: true} = card, player) do
+    %{player |
+      get_out_of_jail: true,
+      card: Enum.reject(player.card, fn c -> c.id == card.id end)  # Remove from player's cards
+    }
+  end
+
+  def apply_effect(%__MODULE__{effect: {:get_out_of_jail, true}}, player) do
+    %{player | get_out_of_jail: true}
+  end
+
+  def apply_effect(_, player), do: player
+
+  # Marks the card as 'owned'
+  def mark_as_owned(card), do: %{card | owned: true}
+end

--- a/lib/monopoly/backend/deck.ex
+++ b/lib/monopoly/backend/deck.ex
@@ -1,0 +1,45 @@
+defmodule GameObjects.Deck do
+  alias GameObjects.Card
+
+  # Initializes the full deck of cards with both Community Chest and Chance cards.
+  def init_deck do
+    init_community_chest() ++ init_chance_cards()
+    |> Enum.shuffle()
+  end
+
+  # Initializes Community Chest cards with appropriate effects.
+  def init_community_chest do
+    [
+      %Card{id: 0, name: "Doctor's fees", type: "community", effect: {:pay, 50}, owned: false},
+      %Card{id: 1, name: "Bank error in your favor", type: "community", effect: {:earn, 200}, owned: false},
+      %Card{id: 2, name: "Get Out of Jail Free", type: "community", effect: {:get_out_of_jail, true}, owned: false},
+      %Card{id: 3, name: "Holiday fund matures", type: "community", effect: {:earn, 100}, owned: false},
+      %Card{id: 4, name: "Hospital Fees", type: "community", effect: {:pay, 50}, owned: false},
+    ]
+  end
+
+  # Initializes Chance cards with appropriate effects.
+  def init_chance_cards do
+    [
+      %Card{id: 5, name: "Bank pays you dividend of $50", type: "chance", effect: {:earn, 50}, owned: false},
+      %Card{id: 6, name: "Pay poor tax of $50", type: "chance", effect: {:pay, 50}, owned: false},
+      %Card{id: 7, name: "You have been elected Chairman of the Board", type: "chance", effect: {:pay, 100}, owned: false},
+      %Card{id: 8, name: "Your building loan matures", type: "chance", effect: {:earn, 150}, owned: false},
+      %Card{id: 9, name: "Get Out of Jail Free", type: "chance", effect: {:get_out_of_jail, true}, owned: false}
+    ]
+  end
+
+  def draw_card(deck) do
+    shuffled_deck = Enum.shuffle(deck)
+
+    case Enum.find(shuffled_deck, &(&1.owned == false)) do
+      nil -> {:error, "No available cards in the deck"}
+      card -> {:ok, card}
+    end
+  end
+
+  def update_deck(deck, updated_card) do
+    Enum.map(deck, fn c -> if c.id == updated_card.id, do: updated_card, else: c end)
+  end
+
+end

--- a/lib/monopoly/backend/deck.ex
+++ b/lib/monopoly/backend/deck.ex
@@ -1,32 +1,29 @@
 defmodule GameObjects.Deck do
   alias GameObjects.Card
+  @cards_path Path.join(:code.priv_dir(:monopoly), "data/cards.json")
 
-  # Initializes the full deck of cards with both Community Chest and Chance cards.
   def init_deck do
-    init_community_chest() ++ init_chance_cards()
+    @cards_path
+    |> File.read!()
+    |> Jason.decode!()
+    |> Enum.map(&parse_card/1)
     |> Enum.shuffle()
   end
 
-  # Initializes Community Chest cards with appropriate effects.
-  def init_community_chest do
-    [
-      %Card{id: 0, name: "Doctor's fees", type: "community", effect: {:pay, 50}, owned: false},
-      %Card{id: 1, name: "Bank error in your favor", type: "community", effect: {:earn, 200}, owned: false},
-      %Card{id: 2, name: "Get Out of Jail Free", type: "community", effect: {:get_out_of_jail, true}, owned: false},
-      %Card{id: 3, name: "Holiday fund matures", type: "community", effect: {:earn, 100}, owned: false},
-      %Card{id: 4, name: "Hospital Fees", type: "community", effect: {:pay, 50}, owned: false},
-    ]
-  end
-
-  # Initializes Chance cards with appropriate effects.
-  def init_chance_cards do
-    [
-      %Card{id: 5, name: "Bank pays you dividend of $50", type: "chance", effect: {:earn, 50}, owned: false},
-      %Card{id: 6, name: "Pay poor tax of $50", type: "chance", effect: {:pay, 50}, owned: false},
-      %Card{id: 7, name: "You have been elected Chairman of the Board", type: "chance", effect: {:pay, 100}, owned: false},
-      %Card{id: 8, name: "Your building loan matures", type: "chance", effect: {:earn, 150}, owned: false},
-      %Card{id: 9, name: "Get Out of Jail Free", type: "chance", effect: {:get_out_of_jail, true}, owned: false}
-    ]
+  defp parse_card(%{
+         "id" => id,
+         "name" => name,
+         "type" => type,
+         "effect" => [effect_type, value],
+         "owned" => owned
+       }) do
+    %Card{
+      id: id,
+      name: name,
+      type: type,
+      effect: {String.to_atom(effect_type), value},
+      owned: owned
+    }
   end
 
   def draw_card(deck, type) do

--- a/lib/monopoly/backend/deck.ex
+++ b/lib/monopoly/backend/deck.ex
@@ -29,10 +29,10 @@ defmodule GameObjects.Deck do
     ]
   end
 
-  def draw_card(deck) do
+  def draw_card(deck, type) do
     shuffled_deck = Enum.shuffle(deck)
 
-    case Enum.find(shuffled_deck, &(&1.owned == false)) do
+    case Enum.find(shuffled_deck, &(&1.owned == false and &1.type == type)) do
       nil -> {:error, "No available cards in the deck"}
       card -> {:ok, card}
     end

--- a/lib/monopoly/backend/game.ex
+++ b/lib/monopoly/backend/game.ex
@@ -6,7 +6,7 @@ defmodule GameObjects.Game do
   """
   require Logger
   use GenServer
-  alias GameObjects.Player
+  alias GameObjects.{Deck, Player}
 
   # CONSTANTS HERE
   # ETS table defined in application.ex
@@ -15,7 +15,7 @@ defmodule GameObjects.Game do
 
   # Game struct definition
   # properties and players are both lists of their respective structs
-  defstruct [:state, :players, :properties, :cards, :current_player, :turn]
+  defstruct [:state, :players, :properties, :deck, :current_player, :turn]
 
   # ---- Public API functions ----
 
@@ -69,6 +69,7 @@ defmodule GameObjects.Game do
       money: 200,
       position: 0,
       sprite_id: 0, # TODO: Randomly assign value
+      cards: [],
       in_jail: false,
       jail_turns: 0
     }
@@ -90,7 +91,7 @@ defmodule GameObjects.Game do
         new_game = %__MODULE__{
           players: [new_player],
           properties: [],
-          cards: [],
+          deck: nil,
           current_player: nil,
           turn: 0
         }
@@ -124,7 +125,8 @@ defmodule GameObjects.Game do
   @impl true
   def handle_call(:start_game, _from, state) do
     if length(state.players) > 1 do
-      updated_state = update_in(state.current_player, List.first(state.players))
+      updated_players = put_in(state.current_player, List.first(state.players))
+      updated_state = put_in(updated_players.deck, Deck.init_deck())
       :ets.insert(@game_store, {:game, updated_state})
       {:reply, {:ok, updated_state}, updated_state}
     else

--- a/lib/monopoly/backend/game.ex
+++ b/lib/monopoly/backend/game.ex
@@ -15,7 +15,7 @@ defmodule GameObjects.Game do
 
   # Game struct definition
   # properties and players are both lists of their respective structs
-  defstruct [:state, :players, :properties, :deck, :current_player, :turn]
+  defstruct [:state, :players, :properties, :deck, :current_player, :active_card, :turn]
 
   # ---- Public API functions ----
 
@@ -93,6 +93,7 @@ defmodule GameObjects.Game do
           properties: [],
           deck: nil,
           current_player: nil,
+          active_acrd: nil,
           turn: 0
         }
 

--- a/lib/monopoly/backend/player.ex
+++ b/lib/monopoly/backend/player.ex
@@ -7,6 +7,6 @@ defmodule GameObjects.Player do
   id is the session id of the player.
   """
 
-  defstruct [:id, :name, :money, :sprite_id, :position, :in_jail, :jail_turns]
+  defstruct [:id, :name, :money, :sprite_id, :position, :cards, :in_jail, :jail_turns]
 
 end

--- a/priv/data/cards.json
+++ b/priv/data/cards.json
@@ -1,0 +1,14 @@
+[
+    { "id": 0, "name": "Doctor's fees", "type": "community", "effect": ["pay", 50], "owned": false },
+    { "id": 1, "name": "Bank error in your favor", "type": "community", "effect": ["earn", 200], "owned": false },
+    { "id": 2, "name": "Get Out of Jail Free", "type": "community", "effect": ["get_out_of_jail", true], "owned": false },
+    { "id": 3, "name": "Holiday fund matures", "type": "community", "effect": ["earn", 100], "owned": false },
+    { "id": 4, "name": "Hospital Fees", "type": "community", "effect": ["pay", 50], "owned": false },
+  
+    { "id": 5, "name": "Bank pays you dividend of $50", "type": "chance", "effect": ["earn", 50], "owned": false },
+    { "id": 6, "name": "Pay poor tax of $50", "type": "chance", "effect": ["pay", 50], "owned": false },
+    { "id": 7, "name": "You have been elected Chairman of the Board", "type": "chance", "effect": ["pay", 100], "owned": false },
+    { "id": 8, "name": "Your building loan matures", "type": "chance", "effect": ["earn", 150], "owned": false },
+    { "id": 9, "name": "Get Out of Jail Free", "type": "chance", "effect": ["get_out_of_jail", true], "owned": false }
+  ]
+  

--- a/test/game_objects/card_test.exs
+++ b/test/game_objects/card_test.exs
@@ -1,0 +1,66 @@
+defmodule GameObjects.CardTest do
+  use ExUnit.Case
+  alias GameObjects.Card
+
+  defmodule Player do
+    defstruct [:id, :name, :money, :sprite_id, :position, :cards, :in_jail, :jail_turns]
+  end
+
+  setup do
+    player = %Player{
+      id: 1,
+      name: "Test",
+      money: 1000,
+      sprite_id: "sprite-1",
+      position: 0,
+      cards: [],
+      in_jail: true,
+      jail_turns: 0
+    }
+
+    {:ok, player: player}
+  end
+
+  describe "apply_effect/2" do
+    test "subtracts money when effect is :pay", %{player: player} do
+      card = %Card{effect: {:pay, 200}}
+      updated = Card.apply_effect(card, player)
+      assert updated.money == 800
+    end
+
+    test "adds money when effect is :earn", %{player: player} do
+      card = %Card{effect: {:earn, 150}}
+      updated = Card.apply_effect(card, player)
+      assert updated.money == 1150
+    end
+
+    test "sets in_jail to false with :get_out_of_jail effect", %{player: player} do
+      card = %Card{effect: {:get_out_of_jail, true}}
+      updated = Card.apply_effect(card, player)
+      assert updated.in_jail == false
+    end
+
+    test "removes owned get-out-of-jail card from player's cards", %{player: player} do
+      card = %Card{id: 99, effect: {:get_out_of_jail, true}, owned: true}
+      player_with_card = %{player | cards: [card]}
+      updated = Card.apply_effect(card, player_with_card)
+
+      assert updated.in_jail == false
+      assert updated.cards == []
+    end
+
+    test "returns unchanged player for unsupported effect", %{player: player} do
+      card = %Card{effect: {:teleport, 3}} # unsupported effect
+      updated = Card.apply_effect(card, player)
+      assert updated == player
+    end
+  end
+
+  describe "mark_as_owned/1" do
+    test "sets card.owned to true" do
+      card = %Card{id: 123, owned: false}
+      updated = Card.mark_as_owned(card)
+      assert updated.owned == true
+    end
+  end
+end

--- a/test/game_objects/deck_test.exs
+++ b/test/game_objects/deck_test.exs
@@ -1,0 +1,91 @@
+defmodule GameObjects.DeckTest do
+  use ExUnit.Case
+  alias GameObjects.{Deck, Card}
+
+  describe "init_deck/0" do
+    test "returns a non-empty shuffled list of cards" do
+      deck = Deck.init_deck()
+      assert is_list(deck)
+      assert length(deck) > 0
+      assert Enum.all?(deck, fn card -> match?(%Card{}, card) end)
+    end
+
+    test "includes both community and chance card types" do
+      deck = Deck.init_deck()
+      types = Enum.map(deck, & &1.type) |> Enum.uniq()
+      assert "community" in types
+      assert "chance" in types
+    end
+
+    test "each card has required fields" do
+      deck = Deck.init_deck()
+
+      Enum.each(deck, fn %Card{} = card ->
+        assert is_integer(card.id)
+        assert is_binary(card.name)
+        assert card.type in ["community", "chance"]
+        assert is_tuple(card.effect)
+        assert is_boolean(card.owned)
+      end)
+    end
+  end
+
+  describe "draw_card/2" do
+    test "returns a card of the community type" do
+      deck = Deck.init_deck()
+      {:ok, card} = Deck.draw_card(deck, "community")
+      assert card.type == "community"
+    end
+
+    test "returns a card of the chance type" do
+      deck = Deck.init_deck()
+      {:ok, card} = Deck.draw_card(deck, "chance")
+      assert card.type == "chance"
+    end
+
+    test "returns different cards on successive draws" do
+      deck = Deck.init_deck()
+      {:ok, card1} = Deck.draw_card(deck, "chance")
+      updated_deck = Deck.update_deck(deck, %{card1 | owned: true})
+      {:ok, card2} = Deck.draw_card(updated_deck, "chance")
+
+      assert card1.id != card2.id
+    end
+
+    test "returns error if no cards of that type are available" do
+      deck = Deck.init_deck()
+      owned_deck = Enum.map(deck, &Map.put(&1, :owned, true))
+      assert {:error, _} = Deck.draw_card(owned_deck, "chance")
+    end
+  end
+
+  describe "update_deck/2" do
+    test "updates the card in the deck with the same id" do
+      deck = Deck.init_deck()
+      [first | _] = deck
+      updated_card = %{first | owned: true}
+      updated_deck = Deck.update_deck(deck, updated_card)
+
+      assert Enum.any?(updated_deck, fn c -> c.id == first.id and c.owned == true end)
+    end
+
+    test "does not modify unrelated cards" do
+      deck = Deck.init_deck()
+      [first | rest] = deck
+      updated_card = %{first | owned: true}
+      updated_deck = Deck.update_deck(deck, updated_card)
+
+      rest_ids = Enum.map(rest, & &1.id)
+      updated_rest_ids = Enum.map(updated_deck -- [updated_card], & &1.id)
+      assert rest_ids == updated_rest_ids
+    end
+
+    test "returns deck of same length after update" do
+      deck = Deck.init_deck()
+      updated_card = %{hd(deck) | owned: true}
+      updated_deck = Deck.update_deck(deck, updated_card)
+
+      assert length(deck) == length(updated_deck)
+    end
+  end
+end


### PR DESCRIPTION
- Added deck module to handle create deck, draw card, update desk when player stores the card
- Added card module to handle apply effect for different type of cards and mark the card as owned if needed
- Add an active_card attribute to the game state, as the user can **pause and choose to store (not required to store)** their "Get Out of Jail" card in their own deck. (@calvinnleeee Please confirm if this logic is correct. If the user doesn't get to choose whether to store the card, the logic can be simplified.)
- Added {GameObjects.Game, []} to appplication.exs to start the gen server
