### PR TITLE
Add Dice module to handle dice rolls

### DIFF
--- a/lib/monopoly/backend/dice.ex
+++ b/lib/monopoly/backend/dice.ex
@@ -3,20 +3,34 @@ defmodule GameObjects.Dice do
   This represents the Dice that are rolled at the start of each player's turn.
   """
 
-  # Roll and return a tuple of two random integers [1-6]
+  # Roll and return a tuple with: individual dice values as a tuple, sum of both dice, and whether it's doubles
   def roll() do
     die1 = :rand.uniform(6)
     die2 = :rand.uniform(6)
-    {die1, die2}
+    sum = die1 + die2
+    is_doubles = die1 == die2
+
+    {{die1, die2}, sum, is_doubles}
+  end
+
+  # check if a player should go to jail based on consecutive doubles
+  def check_for_jail(previous_rolls, {_dice, _sum, is_doubles}) do
+    recent_doubles =
+      previous_rolls
+      |> Enum.take(2)
+      |> Enum.all?(fn {_dice, _sum, doubles} -> doubles end)
+
+    is_doubles and recent_doubles and length(previous_rolls) >= 2
   end
 
   # Determine the outcome of a jail roll based on the dice values and the number of attempts
-  def jail_roll({d1, d2}, attempt_num) do
+  def jail_roll(attempts) do
+    {{die1, die2} = dice, sum, is_doubles} = roll()
+
     cond do
-      d1 == d2 -> {:out_of_jail, {d1, d2}}
-      attempt_num >= 3 -> {:failed_to_escape, {d1, d2}}
-      true -> {:stay_in_jail, {d1, d2}}
+      is_doubles -> {:out_of_jail, dice, sum}
+      attempts >= 2 -> {:failed_to_escape, dice, sum}
+      true -> {:stay_in_jail, dice, sum}
     end
   end
-
 end

--- a/lib/monopoly/backend/dice.ex
+++ b/lib/monopoly/backend/dice.ex
@@ -5,7 +5,18 @@ defmodule GameObjects.Dice do
 
   # Roll and return a tuple of two random integers [1-6]
   def roll() do
-    # return
+    die1 = :rand.uniform(6)
+    die2 = :rand.uniform(6)
+    {die1, die2}
+  end
+
+  # Determine the outcome of a jail roll based on the dice values and the number of attempts
+  def jail_roll({d1, d2}, attempt_num) do
+    cond do
+      d1 == d2 -> {:out_of_jail, {d1, d2}}
+      attempt_num >= 3 -> {:failed_to_escape, {d1, d2}}
+      true -> {:stay_in_jail, {d1, d2}}
+    end
   end
 
 end

--- a/lib/monopoly/backend/dice.ex
+++ b/lib/monopoly/backend/dice.ex
@@ -24,12 +24,12 @@ defmodule GameObjects.Dice do
   end
 
   # Determine the outcome of a jail roll based on the dice values and the number of attempts
-  def jail_roll(attempts) do
+  def jail_roll(jail_turns) do
     {{die1, die2} = dice, sum, is_doubles} = roll()
 
     cond do
       is_doubles -> {:out_of_jail, dice, sum}
-      attempts >= 2 -> {:failed_to_escape, dice, sum}
+      jail_turns >= 2 -> {:failed_to_escape, dice, sum}
       true -> {:stay_in_jail, dice, sum}
     end
   end

--- a/lib/monopoly/frontend/stub.txt
+++ b/lib/monopoly/frontend/stub.txt
@@ -1,0 +1,1 @@
+This is redundant, delete this file when Frontend files added.


### PR DESCRIPTION
- `roll/0` rolls two dice and returns a tuple that contains individual dice values, sum of both dice, and whether the roll is doubles.
- `check_for_jail/2` determines if a player should go to jail after rolling three consecutive doubles.
- `jail_roll/1` handles rolling dice while in jail. It determines if the player escapes or stays.