### PR TITLE
Feature/nathan/win lose condition

### DIFF
--- a/lib/monopoly/backend/game.ex
+++ b/lib/monopoly/backend/game.ex
@@ -89,7 +89,7 @@ defmodule GameObjects.Game do
     GenServer.call(__MODULE__, {:set_player_inactive, session_id})
   end
 
-  # Set a player inactive if they reconnect
+  # Set a player active if they reconnect
   def set_player_active(session_id) do
     GenServer.call(__MODULE__, {:set_player_active, session_id})
   end

--- a/lib/monopoly/backend/player.ex
+++ b/lib/monopoly/backend/player.ex
@@ -15,7 +15,7 @@ defmodule GameObjects.Player do
     @initial_money 1500
     @board_size 40
 
-    defstruct [:id, :name, :money, :sprite_id, :position, :properties, :cards, :in_jail, :jail_turns, :turns_taken, :rolled]
+    defstruct [:id, :name, :money, :sprite_id, :position, :properties, :cards, :in_jail, :jail_turns, :turns_taken, :rolled, :active]
 
     # Type definition: when refering to it, use __MODULE__.t()
     @type t :: %__MODULE__{
@@ -29,7 +29,8 @@ defmodule GameObjects.Player do
         in_jail: boolean(),
         jail_turns: integer(),
         turns_taken: integer(),
-        rolled: boolean()
+        rolled: boolean(),
+        active: boolean()
     }
 
     @doc """


### PR DESCRIPTION
1. Added an active state for each player.
2. Added a winner state for the game.
3. The winner will remain nil unless there's only one players left becoming active. Once that happens, winner will be set to that active player.
4. A player is marked as inactive when their money drops below 0.
5. Added a method for the frontend to set a player as inactive upon disconnection.
6. Added a method for the frontend to reactivate an inactive player upon reconnection, but only if their money is >= 0.
7. ### The frontend is responsible for ending the turn by calling the end_turn if a player disconnects during their turn after being marked inactive.